### PR TITLE
dmm.comの年齢確認を回避

### DIFF
--- a/src/doujin-scraper.ts
+++ b/src/doujin-scraper.ts
@@ -15,6 +15,15 @@ class DoujinScraper {
     const page = await this.browser.newPage()
     await page.goto(`https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=${this.cid}`, { timeout: 60 * 10 * 1000 })
   
+    const click_url = page.url()
+
+    if ( click_url.match(/age_check/)) {
+      await Promise.all([
+        page.click('.ageCheck__link--r18'),
+        page.waitForNavigation()
+      ])
+    }
+
     this.circle = await page.$eval('.circleName__txt', el => el.textContent)
   
     this.title = await page.$eval('.productTitle__txt', title => {


### PR DESCRIPTION
dmmをスクレイピングするときに年齢確認のページを回避しないと
bin/scraper-dmm.shがエラーを吐いて止まるのでクリックして年齢確認のページ回避するようにしました。

いちいちurlを確認してるのは二回目のスクレイピング以降年齢確認のページが現れず逆にクリックするところの処理でエラーが出るので
一回目と二回目以降を区別するようにしました。

レビューをよろしくおねがいします