### PR TITLE
fix: ファイル名にスラッシュが含まれるときのバグを修正

### DIFF
--- a/bin/rename_dlfile.rb
+++ b/bin/rename_dlfile.rb
@@ -1,24 +1,22 @@
 #!/usr/bin/env ruby
 require 'fileutils'
 
-def substitute_special_letters(basename,
-                               special_letters)
-  substitute_name = basename
-  special_letters.each_key do |special_letter|
-    substitute_name = substitute_name.gsub(special_letter,
-                                           special_letters)
+SPECIAL_LETTERS_MAP = {
+  "/" => "\u2044",
+  ":" => "：" # 例えばコロンも対応するとしたら
+}
+def substitute_special_letters(original)
+  sub_name = original.dup
+  SPECIAL_LETTERS_MAP.each do |k, v|
+    sub_name.gsub!(k, v)
   end
-  return substitute_name
+  sub_name
 end
 
-
 BASEDIR = '/app/downloads'
-special_letters = { "/" => "\u2044"}
 
 STDIN.each do |line|
   cid, basename = line.chomp.split("\t")
   org = File.join(BASEDIR, "#{cid}.zip")
-  basename = substitute_special_letters(basename,
-                                       special_letters)
-  FileUtils.mv(org, File.join(BASEDIR, "#{basename}.zip")) if File.file?(org)
+  FileUtils.mv(org, File.join(BASEDIR, "#{substitute_special_letters(basename)}.zip")) if File.file?(org)
 end

--- a/bin/rename_dlfile.rb
+++ b/bin/rename_dlfile.rb
@@ -1,11 +1,24 @@
 #!/usr/bin/env ruby
 require 'fileutils'
 
+def substitute_special_letters(basename,
+                               special_letters)
+  substitute_name = basename
+  special_letters.each_key do |special_letter|
+    substitute_name = substitute_name.gsub(special_letter,
+                                           special_letters)
+  end
+  return substitute_name
+end
+
+
 BASEDIR = '/app/downloads'
+special_letters = { "/" => "\u2044"}
 
 STDIN.each do |line|
   cid, basename = line.chomp.split("\t")
   org = File.join(BASEDIR, "#{cid}.zip")
-  basename.gsub!(%r{\/}, "\u2044") #フォワードスラッシュの代わりに分数スラッシュを使用
+  basename = substitute_special_letters(basename,
+                                       special_letters)
   FileUtils.mv(org, File.join(BASEDIR, "#{basename}.zip")) if File.file?(org)
 end

--- a/bin/rename_dlfile.rb
+++ b/bin/rename_dlfile.rb
@@ -6,5 +6,6 @@ BASEDIR = '/app/downloads'
 STDIN.each do |line|
   cid, basename = line.chomp.split("\t")
   org = File.join(BASEDIR, "#{cid}.zip")
+  basename.gsub!(%r{\/}, "\u2044") #フォワードスラッシュの代わりに分数スラッシュを使用
   FileUtils.mv(org, File.join(BASEDIR, "#{basename}.zip")) if File.file?(org)
 end


### PR DESCRIPTION
ファイル名やサークル名にスラッシュが含まれるとファイル名の制約よりエラーが発生しました。スラッシュを分数スラッシュに変更してバグを修正しました。
ただ、利用者が使っているフォントによってはスラッシュの部分が文字化けするかもしれません。
置き換える先の文字は他にもあると思いますが、暫定として分数スラッシュとしました。

## エラーが起きた環境
ArchLinux 
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]

## エラー

```
bash bin/rename-dmm.sh

Creating doujin-scraper_ruby_run ... done
/usr/local/lib/ruby/2.7.0/fileutils.rb:548:in `rename': No such file or directory @ rb_file_s_rename - (/app/downloads/d_133171.zip, /app/downloads/[禁断童話] 昭和44年夏、脱.包茎！/脱.童貞！.zip) (Errno::ENOENT)
        from /usr/local/lib/ruby/2.7.0/fileutils.rb:548:in `block in mv'
        from /usr/local/lib/ruby/2.7.0/fileutils.rb:1588:in `block in fu_each_src_dest'
        from /usr/local/lib/ruby/2.7.0/fileutils.rb:1604:in `fu_each_src_dest0'
        from /usr/local/lib/ruby/2.7.0/fileutils.rb:1586:in `fu_each_src_dest'
        from /usr/local/lib/ruby/2.7.0/fileutils.rb:539:in `mv'
        from bin/rename_dlfile.rb:10:in `block in <main>'
        from bin/rename_dlfile.rb:6:in `each'
        from bin/rename_dlfile.rb:6:in `<main>'
ERROR: 1
```
## エラーの原因
修正前9行目
`
  FileUtils.mv(org, File.join(BASEDIR, "#{basename}.zip")) if File.file?(org)
`
でFile.join(...)で文字列中の/はエスケープされずそのままディレクトリの構造だと認識され、存在しないフォルダが存在していると認識されます。
この場合実際は
`[禁断童話] 昭和44年夏、脱.包茎！/脱.童貞！.zip`
というファイルを作りたいのですが誤認識で`[禁断童話] 昭和44年夏、脱.包茎！`というフォルダが存在することになります。実際はそのようなフォルダは存在しないので存在しないフォルダ内にFileUtils.mv(...)でファイルをmvしようとしてエラーが起きます。

## エラーが出る作品例
### タイトルに"/"が入っている場合
[禁断童話]昭和44年夏、脱.包茎！/脱.童貞！
https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_133171/
### サークル名に"/"が入っている場合
[ボウテンムスビ/溺愛信仰]巨乳妻たちはレンタル彼氏にハメられて！ 専業主婦、OL上司、ヤンママが…
https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_158044/

レビューをお願いします。